### PR TITLE
fix bug: Eclipse formatter adds space in empty comment lines

### DIFF
--- a/src/java/krasa/formatter/eclipse/JavaCodeFormatterFacade.java
+++ b/src/java/krasa/formatter/eclipse/JavaCodeFormatterFacade.java
@@ -14,6 +14,8 @@ import org.eclipse.text.edits.TextEdit;
 
 import com.intellij.openapi.diagnostic.Logger;
 
+import java.util.regex.Pattern;
+
 /**
  * @author Vojtech Krasa
  */
@@ -102,7 +104,8 @@ public class JavaCodeFormatterFacade extends CodeFormatterFacade {
 			} else {
 				throw new FormattingFailedException(getErrorMessage());
 			}
-			return doc.get();
+			//return doc.get();
+			return Pattern.compile("^([\\s]+\\*)([\\s]+)$", Pattern.MULTILINE).matcher(doc.get()).replaceAll("$1");
 		} catch (BadLocationException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
reference url:
1. http://stackoverflow.com/questions/7008340/eclipse-formatter-adds-space-in-empty-comment-lines
2. https://bugs.eclipse.org/bugs/show_bug.cgi?id=49619

I do not know of any other way to fix this bug. This question bothers me, when I use git.
Thanks!
