### PR TITLE
Made successful formatted confirmation pop-up configurable

### DIFF
--- a/src/java/krasa/formatter/plugin/EclipseCodeStyleManager.java
+++ b/src/java/krasa/formatter/plugin/EclipseCodeStyleManager.java
@@ -123,7 +123,7 @@ public class EclipseCodeStyleManager extends DelegatingCodeStyleManager {
 					}
 				}
 			}
-			if (notify) {
+			if (notify && settings.isEnableSuccessfulFormattingConfirmationPopup()) {
 				notifier.notifySuccessFormatting(psiFile, formattedByIntelliJ);
 			}
 

--- a/src/java/krasa/formatter/plugin/ProjectSettingsForm.form
+++ b/src/java/krasa/formatter/plugin/ProjectSettingsForm.form
@@ -15,7 +15,7 @@
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="46786" layout-manager="GridLayoutManager" row-count="28" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="46786" layout-manager="GridLayoutManager" row-count="29" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints/>
             <properties/>
@@ -23,7 +23,7 @@
             <children>
               <component id="d8281" class="javax.swing.JButton" binding="eclipsePreferenceFilePathJavaBrowse">
                 <constraints>
-                  <grid row="7" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="8" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="action.browse"/>
@@ -31,14 +31,14 @@
               </component>
               <hspacer id="d2ae0">
                 <constraints>
-                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="8" height="11"/>
                   </grid>
                 </constraints>
               </hspacer>
               <component id="b4ea9" class="javax.swing.JCheckBox" binding="optimizeImportsCheckBox" default-binding="true">
                 <constraints>
-                  <grid row="10" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="11" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="350" height="-1"/>
                   </grid>
                 </constraints>
@@ -49,7 +49,7 @@
               </component>
               <component id="eaedb" class="javax.swing.JLabel" binding="eclipseSupportedFileTypesLabel">
                 <constraints>
-                  <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="settings.eclipseSupportedFileTypes"/>
@@ -57,7 +57,7 @@
               </component>
               <component id="af4da" class="javax.swing.JLabel" binding="eclipsePreferenceFileJSLabel">
                 <constraints>
-                  <grid row="15" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="16" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="-1" height="27"/>
                   </grid>
                 </constraints>
@@ -68,7 +68,7 @@
               </component>
               <component id="fcbd9" class="javax.swing.JCheckBox" binding="formatSelectedTextInAllFileTypes">
                 <constraints>
-                  <grid row="26" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="27" column="1" row-span="1" col-span="5" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="settings.formatAllFilesPartial"/>
@@ -76,7 +76,7 @@
               </component>
               <component id="23982" class="javax.swing.JRadioButton" binding="doNotFormatOtherFilesRadioButton">
                 <constraints>
-                  <grid row="23" column="1" row-span="1" col-span="6" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="24" column="1" row-span="1" col-span="6" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="settings.formatOtherFileTypesByIntellij"/>
@@ -84,7 +84,7 @@
               </component>
               <component id="7cabf" class="javax.swing.JRadioButton" binding="formatOtherFilesWithExceptionsRadioButton">
                 <constraints>
-                  <grid row="24" column="1" row-span="1" col-span="3" vsize-policy="1" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="25" column="1" row-span="1" col-span="3" vsize-policy="1" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="settings.disableFileTypesFormattingCheckbox"/>
@@ -92,7 +92,7 @@
               </component>
               <component id="c501b" class="javax.swing.JButton" binding="eclipsePreferenceFilePathJSBrowse">
                 <constraints>
-                  <grid row="15" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="16" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="action.browse"/>
@@ -100,8 +100,8 @@
               </component>
               <component id="ede03" class="javax.swing.JLabel" binding="importOrderLabel">
                 <constraints>
-                  <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-                    <preferred-size width="-1" height="20"/>
+                  <grid row="12" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                    <preferred-size width="155" height="20"/>
                   </grid>
                 </constraints>
                 <properties>
@@ -110,7 +110,7 @@
               </component>
               <component id="4ff2e" class="javax.swing.JTextField" binding="pathToEclipsePreferenceFileJava">
                 <constraints>
-                  <grid row="7" column="3" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="8" column="3" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -120,7 +120,7 @@
               </component>
               <component id="b70f0" class="javax.swing.JTextField" binding="pathToEclipsePreferenceFileJS">
                 <constraints>
-                  <grid row="15" column="3" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="16" column="3" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -130,7 +130,7 @@
               </component>
               <component id="b2c53" class="javax.swing.JLabel" binding="eclipsePrefsExampleJS">
                 <constraints>
-                  <grid row="16" column="3" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="17" column="3" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -142,7 +142,7 @@
               </component>
               <component id="36b8b" class="javax.swing.JTextField" binding="disabledFileTypes">
                 <constraints>
-                  <grid row="24" column="4" row-span="1" col-span="2" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="25" column="4" row-span="1" col-span="2" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -150,7 +150,7 @@
               </component>
               <component id="e0ba8" class="javax.swing.JCheckBox" binding="enableJSFormatting">
                 <constraints>
-                  <grid row="5" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="6" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="settings.enableJS"/>
@@ -158,7 +158,7 @@
               </component>
               <component id="5b5d4" class="javax.swing.JCheckBox" binding="enableJavaFormatting">
                 <constraints>
-                  <grid row="4" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="settings.enableJava"/>
@@ -166,7 +166,7 @@
               </component>
               <component id="4416d" class="javax.swing.JLabel" binding="eclipsePrefsExample">
                 <constraints>
-                  <grid row="8" column="3" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="9" column="3" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -178,7 +178,7 @@
               </component>
               <component id="64315" class="javax.swing.JComboBox" binding="profiles">
                 <constraints>
-                  <grid row="2" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="3" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="60" height="23"/>
                   </grid>
                 </constraints>
@@ -188,7 +188,7 @@
               </component>
               <component id="17ef2" class="javax.swing.JRadioButton" binding="importOrderConfigurationFromFileRadioButton" default-binding="true">
                 <constraints>
-                  <grid row="13" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="14" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="-1" height="20"/>
                   </grid>
                 </constraints>
@@ -198,7 +198,7 @@
               </component>
               <component id="e10b1" class="javax.swing.JRadioButton" binding="importOrderConfigurationManualRadioButton" default-binding="true">
                 <constraints>
-                  <grid row="11" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="12" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="-1" height="23"/>
                   </grid>
                 </constraints>
@@ -208,7 +208,7 @@
               </component>
               <component id="f8e02" class="javax.swing.JFormattedTextField" binding="importOrder">
                 <constraints>
-                  <grid row="11" column="3" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="12" column="3" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -218,7 +218,7 @@
               </component>
               <component id="be43c" class="javax.swing.JLabel" binding="importOrderPreferenceFileExample">
                 <constraints>
-                  <grid row="14" column="3" row-span="1" col-span="4" vsize-policy="0" hsize-policy="2" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="15" column="3" row-span="1" col-span="4" vsize-policy="0" hsize-policy="2" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -230,7 +230,7 @@
               </component>
               <component id="2c7b4" class="javax.swing.JTextField" binding="pathToImportOrderPreferenceFile">
                 <constraints>
-                  <grid row="13" column="3" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="14" column="3" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -240,7 +240,7 @@
               </component>
               <component id="b82e7" class="javax.swing.JLabel" binding="importOrderManualExample">
                 <constraints>
-                  <grid row="12" column="3" row-span="1" col-span="3" vsize-policy="0" hsize-policy="2" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="13" column="3" row-span="1" col-span="3" vsize-policy="0" hsize-policy="2" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -252,7 +252,7 @@
               </component>
               <component id="7f44d" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="30" height="-1"/>
                   </grid>
                 </constraints>
@@ -262,7 +262,7 @@
               </component>
               <component id="fd68d" class="javax.swing.JButton" binding="pathToImportOrderPreferenceFileBrowse">
                 <constraints>
-                  <grid row="13" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="14" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="action.browse"/>
@@ -270,7 +270,7 @@
               </component>
               <component id="cd640" class="javax.swing.JLabel" binding="eclipsePreferenceFileJavaLabel">
                 <constraints>
-                  <grid row="7" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="-1" height="27"/>
                   </grid>
                 </constraints>
@@ -281,7 +281,7 @@
               </component>
               <component id="d2643" class="javax.swing.JComboBox" binding="javaFormatterProfile">
                 <constraints>
-                  <grid row="9" column="3" row-span="1" col-span="3" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="10" column="3" row-span="1" col-span="3" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="23"/>
                   </grid>
                 </constraints>
@@ -289,7 +289,7 @@
               </component>
               <component id="1a4f3" class="javax.swing.JLabel" binding="javaFormatterProfileLabel">
                 <constraints>
-                  <grid row="9" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="10" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="-1" height="27"/>
                   </grid>
                 </constraints>
@@ -300,7 +300,7 @@
               </component>
               <component id="535c9" class="javax.swing.JButton" binding="delete">
                 <constraints>
-                  <grid row="2" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <hideActionText value="false"/>
@@ -309,7 +309,7 @@
               </component>
               <component id="e7a7e" class="javax.swing.JButton" binding="copyProfile">
                 <constraints>
-                  <grid row="3" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="4" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Copy profile"/>
@@ -317,7 +317,7 @@
               </component>
               <component id="bdccd" class="javax.swing.JButton" binding="newProfile">
                 <constraints>
-                  <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="4" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="New profile"/>
@@ -325,7 +325,7 @@
               </component>
               <component id="9fe18" class="javax.swing.JButton" binding="rename">
                 <constraints>
-                  <grid row="2" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <hideActionText value="false"/>
@@ -334,7 +334,7 @@
               </component>
               <component id="aaee7" class="javax.swing.JLabel" binding="disabledFileTypesHelpLabel">
                 <constraints>
-                  <grid row="25" column="4" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="26" column="4" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -346,12 +346,14 @@
               </component>
               <vspacer id="57011">
                 <constraints>
-                  <grid row="27" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                  <grid row="28" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+                    <preferred-size width="155" height="14"/>
+                  </grid>
                 </constraints>
               </vspacer>
               <component id="79d02" class="javax.swing.JCheckBox" binding="enableJavaScriptCommentsPostProcessor">
                 <constraints>
-                  <grid row="18" column="2" row-span="1" col-span="5" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="19" column="2" row-span="1" col-span="5" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="350" height="-1"/>
                   </grid>
                 </constraints>
@@ -362,7 +364,7 @@
               </component>
               <component id="47b9f" class="javax.swing.JLabel" binding="formatterProfileLabelJS">
                 <constraints>
-                  <grid row="17" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="18" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="-1" height="27"/>
                   </grid>
                 </constraints>
@@ -373,7 +375,7 @@
               </component>
               <component id="a0d68" class="javax.swing.JComboBox" binding="formatterProfileJS">
                 <constraints>
-                  <grid row="17" column="3" row-span="1" col-span="3" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="18" column="3" row-span="1" col-span="3" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="23"/>
                   </grid>
                 </constraints>
@@ -395,7 +397,7 @@
               <component id="a7c42" class="javax.swing.JRadioButton" binding="useEclipseFormatter">
                 <constraints>
                   <grid row="1" column="0" row-span="1" col-span="6" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-                    <preferred-size width="30" height="-1"/>
+                    <preferred-size width="30" height="31"/>
                   </grid>
                 </constraints>
                 <properties>
@@ -437,7 +439,7 @@
               </component>
               <component id="a9ba" class="javax.swing.JCheckBox" binding="useForLiveTemplates">
                 <constraints>
-                  <grid row="22" column="1" row-span="1" col-span="6" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="23" column="1" row-span="1" col-span="6" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Use for Live Templates (might break caret and selection positioning, if IntelliJ code style is different, e.g. tabs vs spaces)"/>
@@ -445,7 +447,7 @@
               </component>
               <component id="919a" class="javax.swing.JCheckBox" binding="enableCppFormatting">
                 <constraints>
-                  <grid row="5" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="6" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="settings.enable.cpp"/>
@@ -453,7 +455,7 @@
               </component>
               <component id="9f96b" class="javax.swing.JLabel" binding="eclipsePreferenceFileCppLabel">
                 <constraints>
-                  <grid row="19" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="20" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="-1" height="27"/>
                   </grid>
                 </constraints>
@@ -464,7 +466,7 @@
               </component>
               <component id="92aa9" class="javax.swing.JTextField" binding="pathToEclipsePreferenceFileCpp">
                 <constraints>
-                  <grid row="19" column="3" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="20" column="3" row-span="1" col-span="3" vsize-policy="1" hsize-policy="3" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -474,7 +476,7 @@
               </component>
               <component id="2f5f1" class="javax.swing.JLabel" binding="eclipsePrefsExampleCpp">
                 <constraints>
-                  <grid row="20" column="3" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="21" column="3" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="20"/>
                   </grid>
                 </constraints>
@@ -486,7 +488,7 @@
               </component>
               <component id="60928" class="javax.swing.JLabel" binding="formatterProfileLabelCpp">
                 <constraints>
-                  <grid row="21" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                  <grid row="22" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                     <preferred-size width="-1" height="27"/>
                   </grid>
                 </constraints>
@@ -497,7 +499,7 @@
               </component>
               <component id="977af" class="javax.swing.JComboBox" binding="formatterProfileCpp">
                 <constraints>
-                  <grid row="21" column="3" row-span="1" col-span="3" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="22" column="3" row-span="1" col-span="3" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="20" height="23"/>
                   </grid>
                 </constraints>
@@ -507,7 +509,7 @@
               </component>
               <component id="c1e79" class="javax.swing.JButton" binding="eclipsePreferenceFilePathCppBrowse">
                 <constraints>
-                  <grid row="19" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="20" column="6" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="action.browse"/>
@@ -515,7 +517,7 @@
               </component>
               <component id="3a72e" class="javax.swing.JCheckBox" binding="enableGWTNativeMethodsCheckBox" default-binding="true">
                 <constraints>
-                  <grid row="4" column="4" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="5" column="4" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Enable GWT native methods formatting"/>
@@ -523,10 +525,18 @@
               </component>
               <component id="e49b2" class="javax.swing.JCheckBox" binding="useOldEclipseJavaFormatter">
                 <constraints>
-                  <grid row="6" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="7" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text resource-bundle="krasa/formatter/messages" key="settings.use.legacy.eclipse.formatter"/>
+                </properties>
+              </component>
+              <component id="51673" class="javax.swing.JCheckBox" binding="enableSuccessfulFormattingConfirmationPopup">
+                <constraints>
+                  <grid row="2" column="1" row-span="1" col-span="6" vsize-policy="0" hsize-policy="1" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Display confirmation pop-up after successful formatting"/>
                 </properties>
               </component>
             </children>

--- a/src/java/krasa/formatter/plugin/ProjectSettingsForm.java
+++ b/src/java/krasa/formatter/plugin/ProjectSettingsForm.java
@@ -50,6 +50,8 @@ public class ProjectSettingsForm {
 
 	private JRadioButton useDefaultFormatter;
 	private JRadioButton useEclipseFormatter;
+	
+	private JCheckBox enableSuccessfulFormattingConfirmationPopup;
 
 	private JLabel eclipseSupportedFileTypesLabel;
 
@@ -118,8 +120,8 @@ public class ProjectSettingsForm {
 
 	private void updateComponents() {
 		hidePopups();
-		enabledBy(new JComponent[] { eclipseSupportedFileTypesLabel, enableJavaFormatting, enableJSFormatting,
-				enableCppFormatting,
+		enabledBy(new JComponent[] { enableSuccessfulFormattingConfirmationPopup, eclipseSupportedFileTypesLabel, 
+				enableJavaFormatting, enableJSFormatting, enableCppFormatting,
 				doNotFormatOtherFilesRadioButton, formatOtherFilesWithExceptionsRadioButton,
 				importOrderPreferenceFileExample, importOrderConfigurationFromFileRadioButton,
 				importOrderConfigurationManualRadioButton, formatSelectedTextInAllFileTypes, useForLiveTemplates }, useEclipseFormatter);
@@ -200,7 +202,7 @@ public class ProjectSettingsForm {
 		JToggleButton[] modifiableButtons = new JToggleButton[] { useDefaultFormatter, useEclipseFormatter,
 				optimizeImportsCheckBox, enableJavaFormatting, doNotFormatOtherFilesRadioButton,
 				formatOtherFilesWithExceptionsRadioButton, formatSelectedTextInAllFileTypes, enableJSFormatting,
-				enableCppFormatting,
+				enableCppFormatting, enableSuccessfulFormattingConfirmationPopup,
 				importOrderConfigurationManualRadioButton, importOrderConfigurationFromFileRadioButton,
 				enableGWTNativeMethodsCheckBox };
 		for (JToggleButton button : modifiableButtons) {
@@ -734,6 +736,7 @@ public class ProjectSettingsForm {
 	}
 
 	public void setData(Settings data) {
+		enableSuccessfulFormattingConfirmationPopup.setSelected(data.isEnableSuccessfulFormattingConfirmationPopup());
 		optimizeImportsCheckBox.setSelected(data.isOptimizeImports());
 		formatSelectedTextInAllFileTypes.setSelected(data.isFormatSeletedTextInAllFileTypes());
 		pathToEclipsePreferenceFileJava.setText(data.getPathToConfigFileJava());
@@ -752,6 +755,7 @@ public class ProjectSettingsForm {
 	}
 
 	public void getData(Settings data) {
+		data.setEnableSuccessfulFormattingConfirmationPopup(enableSuccessfulFormattingConfirmationPopup.isSelected());
 		data.setOptimizeImports(optimizeImportsCheckBox.isSelected());
 		data.setFormatSeletedTextInAllFileTypes(formatSelectedTextInAllFileTypes.isSelected());
 		data.setPathToConfigFileJava(pathToEclipsePreferenceFileJava.getText());
@@ -774,6 +778,7 @@ public class ProjectSettingsForm {
 		if (customIsModified(data)) {
 			return true;
 		}
+		if (enableSuccessfulFormattingConfirmationPopup.isSelected() != data.isEnableSuccessfulFormattingConfirmationPopup()) return true;
 		if (optimizeImportsCheckBox.isSelected() != data.isOptimizeImports()) return true;
 		if (formatSelectedTextInAllFileTypes.isSelected() != data.isFormatSeletedTextInAllFileTypes()) return true;
 		if (pathToEclipsePreferenceFileJava.getText() != null ? !pathToEclipsePreferenceFileJava.getText().equals(data.getPathToConfigFileJava()) : data.getPathToConfigFileJava() != null)

--- a/src/java/krasa/formatter/settings/Settings.java
+++ b/src/java/krasa/formatter/settings/Settings.java
@@ -25,6 +25,8 @@ public class Settings {
 
 	private String name = null;
 	private Long id = null;
+    
+    private boolean enableSuccessfulFormattingConfirmationPopup = true;
 
 	private String pathToConfigFileJS = "";
 	private String pathToConfigFileCpp = "";
@@ -68,8 +70,17 @@ public class Settings {
 		this.id = id;
 		this.name = name;
 	}
+    
+    public boolean isEnableSuccessfulFormattingConfirmationPopup() {
+        return enableSuccessfulFormattingConfirmationPopup;
+    }
 
-	public DisabledFileTypeSettings geDisabledFileTypeSettings() {
+    public void setEnableSuccessfulFormattingConfirmationPopup(
+            final boolean enableSuccessfulFormattingConfirmationPopup) {
+        this.enableSuccessfulFormattingConfirmationPopup = enableSuccessfulFormattingConfirmationPopup;
+    }
+
+    public DisabledFileTypeSettings geDisabledFileTypeSettings() {
 		return new DisabledFileTypeSettings(disabledFileTypes);
 	}
 


### PR DESCRIPTION
After each succesful formatting using the plugin, an information pop-up with the text "MyClass.java formatted successfully by Eclipse code formatter" is shown. When configuring IntelliJ to reformat after each file save, this can be quite annoying, as it covers the tabs of other classes where I would like to navigate to right after saving. Therefore, I need to wait or manually close that pop-up, which is an unnecessary extra-click each time.

My pull request will add a new check-box above the profile selection (as it is a general setting where it makes no sense to include to a profile). If enabled, the confirmation pop-up is shown, if disabled, it is not. By default it is enabled.

Here is a mock-up of how it looks:
![mockup_eclipseformatter_settings](https://cloud.githubusercontent.com/assets/1215256/8913589/1bb9409e-349a-11e5-833d-e0d0fb83b46a.png)

And here a screenshot of the pop-up I am talking about:
![confirmation_popup](https://cloud.githubusercontent.com/assets/1215256/8913653/8afe0688-349a-11e5-96ca-1fa1a0b1566d.png)