### PR TITLE
2019.2 compat: Add com.intellij.modules.java, fix ClassCastException

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -164,6 +164,7 @@
     ]]></change-notes>
 
 	<depends>com.intellij.modules.lang</depends>
+	<depends>com.intellij.modules.java</depends>
 
 	<application-components>
 		<component>


### PR DESCRIPTION
- Add a dependency on com.intellij.modules.java. This is now required
for 2019.2 compatibility (see links below).
- This also fixes the NoClassDefFoundError, ClassNotFoundException for
com.intellij.psi.PsiJavaFile and
com.intellij.psi.impl.JavaPsiImplementationHelper that would occur when
EclipseFormatter is used as a bundled plugin (i.e. put directly into the
installation /plugins folder rather than installing it from the plugin
repository).

Official announcements and documentation:
https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/
http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html